### PR TITLE
Add `application/json` as a MIME type for .json files

### DIFF
--- a/lottie-lite.php
+++ b/lottie-lite.php
@@ -129,11 +129,13 @@ add_filter( 'render_block', function( string $block_content, array $block ) : st
  */
 add_filter( 'upload_mimes', function( $mime_types ) {
 	$mime_types['json'] = 'text/plain'; // This is needed to allow uploading the file type.
+	$mime_types['json'] = 'application/json'; // This is needed to allow uploading the file type.
 	$mime_types['lottie'] = 'application/zip';
 	return $mime_types;
 } );
 add_filter( 'mime_types', function( $mime_types ) {
 	$mime_types['json'] = 'text/plain';
+	$mime_types['json'] = 'application/json';
 	$mime_types['lottie'] = 'application/zip';
 	return $mime_types;
 } );


### PR DESCRIPTION
Fixes https://github.com/humanmade/lottie-lite/issues/10 for when a server recognizes the `.json` file's MIME type as `application/json` instead of `text/plain`.

Test this on a computer where the following is true:

```
$ file -I lottie.json 
lottie.json: application/json; charset=utf-8
```