### PR TITLE
Support for aria-hidden

### DIFF
--- a/build/lottie.asset.php
+++ b/build/lottie.asset.php
@@ -1,1 +1,1 @@
-<?php return array('dependencies' => array(), 'version' => '46c1b84cff8580aa9161');
+<?php return array('dependencies' => array(), 'version' => '65349e13f2d98dcdd702');

--- a/build/lottie.js
+++ b/build/lottie.js
@@ -104,12 +104,23 @@ __webpack_require__.r(__webpack_exports__);
 /* harmony import */ var _lottie_css__WEBPACK_IMPORTED_MODULE_1__ = __webpack_require__(/*! ./lottie.css */ "./src/lottie.css");
 
 
+function createCanvas(config = {}) {
+  const canvas = document.createElement('canvas');
+  canvas.id = config.id;
+
+  // If the fallback image has no alt text, it's decorative
+  if (config.alt === '') {
+    canvas.ariaHidden = true;
+  }
+  return canvas;
+}
 document.querySelectorAll('[data-lottie]').forEach(lottie => {
   const config = JSON.parse(lottie.dataset.lottie);
   const img = lottie.querySelector('img');
   if (!img) {
     return;
   }
+  config.alt = img.alt.trim();
 
   // Check if this is a cover block
   const isCoverBlock = lottie.classList.contains('wp-block-cover');
@@ -123,8 +134,7 @@ document.querySelectorAll('[data-lottie]').forEach(lottie => {
     if (fallback === 'show-first-frame' || fallback === 'show-last-frame') {
       lottie.classList.add('lottie-img-hidden');
       lottie.classList.add('lottie-lite-reduced-motion-container');
-      const canvas = document.createElement('canvas');
-      canvas.id = config.id;
+      const canvas = createCanvas(config);
       canvas.style.opacity = 1.0;
       canvas.style.width = img.style.width || '100%';
       canvas.style.height = img.style.height || '100%';
@@ -163,8 +173,7 @@ document.querySelectorAll('[data-lottie]').forEach(lottie => {
   }
 
   // Create canvas.
-  const canvas = document.createElement('canvas');
-  canvas.id = config.id;
+  const canvas = createCanvas(config);
   const isLazy = img.loading === 'lazy';
 
   // Append - ensure if a link is used the canvas is inside to pick up clickable area.

--- a/src/lottie.js
+++ b/src/lottie.js
@@ -2,6 +2,17 @@ import { DotLottie } from '@lottiefiles/dotlottie-web';
 
 import './lottie.css';
 
+function createCanvas( config = {} ) {
+    const canvas = document.createElement( 'canvas' );
+    canvas.id = config.id;
+
+    // If the fallback image has no alt text, it's decorative
+    if ( config.alt === '' ) {
+        canvas.ariaHidden = true
+    }
+    return canvas;
+}
+
 document.querySelectorAll( '[data-lottie]' ).forEach( ( lottie ) => {
 	const config = JSON.parse( lottie.dataset.lottie );
 	const img = lottie.querySelector( 'img' );
@@ -10,7 +21,9 @@ document.querySelectorAll( '[data-lottie]' ).forEach( ( lottie ) => {
 		return;
 	}
 
-	// Check if this is a cover block
+    config.alt = img.alt.trim()
+
+    // Check if this is a cover block
 	const isCoverBlock = lottie.classList.contains( 'wp-block-cover');
 
 	// Accessibility: Detect prefers-reduced-motion
@@ -22,9 +35,8 @@ document.querySelectorAll( '[data-lottie]' ).forEach( ( lottie ) => {
 		if (fallback === 'show-first-frame' || fallback === 'show-last-frame') {
 			lottie.classList.add('lottie-img-hidden');
 			lottie.classList.add('lottie-lite-reduced-motion-container');
-			const canvas = document.createElement('canvas');
-			canvas.id = config.id;
 
+            const canvas = createCanvas(config);
 			canvas.style.opacity = 1.0;
 			canvas.style.width = img.style.width || '100%';
 			canvas.style.height = img.style.height || '100%';
@@ -64,8 +76,7 @@ document.querySelectorAll( '[data-lottie]' ).forEach( ( lottie ) => {
 	}
 
 	// Create canvas.
-	const canvas = document.createElement( 'canvas' );
-	canvas.id = config.id;
+    const canvas = createCanvas(config);
 
 	const isLazy = img.loading === 'lazy';
 


### PR DESCRIPTION
The PR introduces a reusable helper that centralizes how canvas elements for Lottie animations are created. 

Before creating a canvas, it now copies the fallback image’s trimmed text into the Lottie configuration. If that text is an empty string, the canvas is marked `aria-hidden`, treating the animation as decorative for screen readers. 

All previous inline usages are replaced with calls to this helper, reducing duplication and ensuring consistent accessibility behavior. 